### PR TITLE
Load the default config file if there isn't a file in the project.

### DIFF
--- a/src/EnvChecker/EnvCheckerServiceProvider.php
+++ b/src/EnvChecker/EnvCheckerServiceProvider.php
@@ -30,6 +30,11 @@ class EnvCheckerServiceProvider extends ServiceProvider
      */
     public function register()
     {
+        $this->mergeConfigFrom(
+            __DIR__ . '/Config/envchecker.php',
+            'envchecker'
+        );
+
         $this->commands($this->commands);
     }
 }


### PR DESCRIPTION
I received an error while running php artisan env:check because I didn't publish the config file. With this addition it takes the config file from the package if the project doesn't has that config file.